### PR TITLE
use AppImage-based linux client

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -178,9 +178,12 @@ Vagrant.configure("2") do |config|
       rm -rf boundery-linux-client*
       wget https://boundery.me/static/clients/boundery-linux-client.tar.gz
       tar zxvf boundery-linux-client.tar.gz
+      pushd boundery-linux-client
+      ./Boundery_Client-*-x86_64.AppImage --appimage-extract
+      popd
 
       #Make root cert available to client's embedded ca list.
-      cp /etc/ssl/certs/ca-certificates.crt boundery-linux-client/app_packages/certifi/cacert.pem
+      cp /etc/ssl/certs/ca-certificates.crt boundery-linux-client/squashfs-root/usr/app_packages/certifi/cacert.pem
 
       #Make root cert available to chromium/chromedriver's embedded ca list.
       rm -rf .pki

--- a/run_test.sh
+++ b/run_test.sh
@@ -49,7 +49,7 @@ while ! ss -tln | grep -q ':9999'; do
     sleep 1
 done
 
-ZIPFILE_NAME="$1" BROWSER=/vagrant/fake_browser.sh boundery-linux-client/Boundery\ Client &
+ZIPFILE_NAME="$1" BROWSER=/vagrant/fake_browser.sh boundery-linux-client/squashfs-root/AppRun &
 
 fg %3 #tester
 jobs


### PR DESCRIPTION
Fixes tests with the AppImage-based linux client in the client repo's geogriff/briefcase-0.3 branch.

Tested `make test-linux-pczip` with os master and client geogriff/briefcase-0.3 branch.